### PR TITLE
Dockerfile for use on internal Allan Gray machines

### DIFF
--- a/docker-image-allan-gray-internal/Dockerfile
+++ b/docker-image-allan-gray-internal/Dockerfile
@@ -1,0 +1,36 @@
+FROM docker-registry.public-upstream.gray.net/conda/miniconda3:latest
+
+MAINTAINER Leon van Dyk <leon.vandyk@technovolve.co.za>
+
+RUN apt-get update && \
+    apt-get install -y curl git  && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/AllanGrayEnterpriseRootCA.crt' -o '/usr/local/share/ca-certificates/AllanGrayEnterpriseRootCA.crt' && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/AllanGrayIssuingCA01.crt' -o '/usr/local/share/ca-certificates/AllanGrayIssuingCA01.crt' && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/AllanGrayIssuingCA02.crt' -o '/usr/local/share/ca-certificates/AllanGrayIssuingCA02.crt' && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/rootSHA256.cer' -o '/usr/local/share/ca-certificates/rootSHA256.crt' && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/issuingca1SHA256.cer' -o '/usr/local/share/ca-certificates/issuingca1SHA256.crt' && \
+    curl -ks 'https://ataboymirror-agct.gray.net/reliable_deployments/ssl_certs/issuingca2SHA256.cer' -o '/usr/local/share/ca-certificates/issuingca2SHA256.crt' && \
+    /usr/sbin/update-ca-certificates
+
+RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --upgrade pip
+    
+RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org 'tensorflow==1.6.0' pandas matplotlib jupyter 'pillow==5.0.0' 'formencode==1.3.1'
+
+RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org cherrypy==14.0.0 --ignore-installed
+
+RUN mkdir -p /root/downloads && \
+    cd /root/downloads && \
+    curl -O http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server/t/tensorflow-model-server/tensorflow-model-server_1.5.0_all.deb && \
+    dpkg -i tensorflow-model-server_1.5.0_all.deb && \
+    apt-get install -f && \
+    curl -L https://pypi.python.org/packages/b5/fc/b703b884743f312603ced4aaddac023e79d38e05b5ece31d1d9aabfdf494/tensorflow_serving_api-1.5.0-py2-none-any.whl > tensorflow_serving_api-1.5.0-py3-none-any.whl && \
+    pip install tensorflow_serving_api-1.5.0-py3-none-any.whl && \
+    cd / && \
+    rm -r /root/downloads && \
+    mkdir -p /root/source
+
+EXPOSE 8888 9000
+
+WORKDIR /root/source
+
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--no-browser", "--allow-root", "--NotebookApp.token="]

--- a/docker-image-allan-gray-internal/readme.md
+++ b/docker-image-allan-gray-internal/readme.md
@@ -7,7 +7,7 @@ I have a powerful personal laptop, but it came with Windows Home.  Windows Home 
 ## Possible Solutions
 
 1. Install the (much) older Docker Toolkit, which creates a docker image on a headless version of Virtualbox.
-    * We use Docker Toolbox on our build machine and have had problems with it.  Also, I'm not sure how compatible it is with the laters docker features.  I didn't want to fiddle around and waste time.
+    * We use Docker Toolbox on our build machine and have had problems with it.  Also, I'm not sure how compatible it is with the latest docker features.  I didn't want to fiddle around and waste time.
 1. Install Ubuntu and dual boot.
     * Just got back from leave, don't have time by tonight.
 1. Get things running on my work computer and Remote into that.
@@ -16,7 +16,7 @@ I have a powerful personal laptop, but it came with Windows Home.  Windows Home 
 
 ## Modified Docker file    
 
-The Dockerfile as supplied will not build on a computer on the Allan Gray internal network because Websence intercepts or HTTPS traffic.  You get this error:
+The Dockerfile as supplied will not build on a computer on the Allan Gray internal network because Websense intercepts or HTTPS traffic.  You get this error:
 
 ````
 RUN pip install --upgrade pip

--- a/docker-image-allan-gray-internal/readme.md
+++ b/docker-image-allan-gray-internal/readme.md
@@ -1,0 +1,28 @@
+# Dockerfile for Host on the internal Allan Gray network
+
+Some of the attendees may be experieicing the problems I have.
+
+I have a powerful personal laptop, but it came with Windows Home.  Windows Home does not support Hypervisor, and therefore cannot run Docker for Windows.
+
+## Possible Solutions
+
+1. Install the (much) older Docker Toolkit, which creates a docker image on a headless version of Virtualbox.
+    * We use Docker Toolbox on our build machine and have had problems with it.  Also, I'm not sure how compatible it is with the laters docker features.  I didn't want to fiddle around and waste time.
+1. Install Ubuntu and dual boot.
+    * Just got back from leave, don't have time by tonight.
+1. Get things running on my work computer and Remote into that.
+    * I've chosen this for now.  I'll probably go back to number 2 at some point, as I've been meaning to do that for a while.
+
+
+## Modified Docker file    
+
+The Dockerfile as supplied will not build on a computer on the Allan Gray internal network because Websence intercepts or HTTPS traffic.  You get this error:
+
+````
+RUN pip install --upgrade pip
+ ---> Running in 89da8b59fb4a
+Could not fetch URL https://pypi.python.org/simple/pip/: There was a problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749)
+````
+
+I have modified the Dockerfile to work on an Allan Gray computer by specifying `--trusted-host`s.  I have also copied in the Allan Gray root certificate; it may not be needed to build, but may prevent issues further down the line.
+


### PR DESCRIPTION
The Dockerfile as supplied will not build on a computer on the Allan Gray internal network because Websense intercepts or HTTPS traffic.  Here's one which will work.  More info on the readme,